### PR TITLE
fix: update to publish package with sboms included

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -70,7 +70,7 @@ tasks:
           dep_commands: "./uds run dependencies:create"
       - task: setup:k3d-test-cluster
       - task: deploy:test-bundle
-      - task: create-dev-package      
+      - task: create-dev-package
       - task: create-deploy-test-bundle
 
   - name: publish-package

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -40,7 +40,6 @@ tasks:
   - name: create-deploy-test-bundle
     description: Test and validate cluster is deployed with Confluence
     actions:
-      - task: create-dev-package
       - task: dependencies:create
       - task: create:test-bundle
       - task: deploy:test-bundle
@@ -71,6 +70,7 @@ tasks:
           dep_commands: "./uds run dependencies:create"
       - task: setup:k3d-test-cluster
       - task: deploy:test-bundle
+      - task: create-dev-package      
       - task: create-deploy-test-bundle
 
   - name: publish-package


### PR DESCRIPTION
The `create-deploy-test-bundle` task was calling `create-dev-package` which skips sbom creation. Since `create-deploy-test-bundle` was called from `publish-package` this means that the published packages contain no sboms. 

```
zarf package pull oci://ghcr.io/defenseunicorns/packages/uds/artifactory:7.104.14-uds.0-registry1
2025-04-02 09:33:00 INF starting pull from oci source src=oci://ghcr.io/defenseunicorns/packages/uds/artifactory:7.104.14-uds.0-registry1 digest=
2025-04-02 09:33:03 INF Pulling ghcr.io/defenseunicorns/packages/uds/artifactory:7.104.14-uds.0-registry1, size: 2.27 GBs

zarf package inspect sbom zarf-package-artifactory-amd64-7.104.14-uds.0.tar.zst 
2025-04-02 09:34:24 ERR could not get SBOM: opening archive file: open /var/folders/0d/4c5mdtpx1470663vgw5fzb0h0000gp/T/zarf-619483583/sboms.tar: no such file or directory
```

Updated to remove `create-dev-package` from `create-deploy-test-bundle` and explicitly call `create-dev-package` only where it is needed.


Side benefit: This will save time on the runners because we aren't rebuilding the package extra times.