### PR TITLE
feature: automating openid oauth sso provider creation and adding license through a secret

### DIFF
--- a/chart/templates/artifactory-license-secret.yaml
+++ b/chart/templates/artifactory-license-secret.yaml
@@ -1,0 +1,12 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: artifactory-license
+  namespace:  {{ .Release.Namespace }}
+type: "Opaque"
+stringData:
+  license: |
+    {{- .Values.license | nindent 4 }}

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -26,6 +26,13 @@ spec:
             - "{{ . }}"
           {{- end }}
         {{- end }}
+      secretName: artifactory-keycloak-client
+      secretTemplate:
+        artifactory_client_id: "clientField(clientId)"
+        artifactory_client_secret: "clientField(secret)"
+        keycloak_auth_url: "https://sso.{{ .Values.domain }}/realms/uds/protocol/openid-connect/auth"
+        keycloak_token_url: "https://sso.{{ .Values.domain }}/realms/uds/protocol/openid-connect/token"
+        keycloak_api_url: "https://sso.{{ .Values.domain }}/realms/uds/protocol/openid-connect/userinfo"
   {{- end }}
   network:
     expose:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -38,6 +38,8 @@ postgres:
   namespace: postgres
   port: 5432
 
+license: ""
+
 # customNetworkPolicies:
 #    # Notice no `remoteGenerated` field here on custom internal rule
 #   - direction: Ingress

--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -50,6 +50,46 @@ components:
             shell:
               darwin: bash
               linux: bash
+          - cmd: |
+              ADMIN_USER=$(uds zarf tools kubectl get secret artifactory-admin-credentials -n artifactory -o=jsonpath='{.data.username}' | base64 -d)
+              ADMIN_PASS=$(uds zarf tools kubectl get secret artifactory-admin-credentials -n artifactory -o=jsonpath='{.data.password}' | base64 -d)
+              
+              CLIENT_ID=$(uds zarf tools kubectl get secret artifactory-keycloak-client -n artifactory -o=jsonpath='{.data.artifactory_client_id}' | base64 -d)
+              CLIENT_SECRET=$(uds zarf tools kubectl get secret artifactory-keycloak-client -n artifactory -o=jsonpath='{.data.artifactory_client_secret}' | base64 -d)
+              AUTH_URL=$(uds zarf tools kubectl get secret artifactory-keycloak-client -n artifactory -o=jsonpath='{.data.keycloak_auth_url}' | base64 -d)
+              API_URL=$(uds zarf tools kubectl get secret artifactory-keycloak-client -n artifactory -o=jsonpath='{.data.keycloak_api_url}' | base64 -d)
+              TOKEN_URL=$(uds zarf tools kubectl get secret artifactory-keycloak-client -n artifactory -o=jsonpath='{.data.keycloak_token_url}' | base64 -d)
+              
+              echo "Setting up OpenID OAuth SSO using ${CLIENT_ID}"
+              echo "Auth: ${AUTH_URL}"
+              echo "Token: ${TOKEN_URL}"
+              echo "API: ${API_URL}"
+    
+              curl -u "${ADMIN_USER}:${ADMIN_PASS}" -X POST "https://artifactory.${ZARF_VAR_DOMAIN}/artifactory/api/oauth" \
+                  -H "Content-Type: application/json" \
+                  -d @- <<EOF
+              {
+                  "enabled": false,
+                  "persistUsers": true,
+                  "allowUserToAccessProfile": true,
+                  "groupClaimName": "groups",
+                  "oauthProvidersSettings": [
+                      {
+                      "name": "Login with OpenID",
+                      "type": "openid",
+                      "clientId": "${CLIENT_ID}",
+                      "clientSecret": "${CLIENT_SECRET}",
+                      "authorizationEndpoint": "${AUTH_URL}",
+                      "tokenEndpoint": "${TOKEN_URL}",
+                      "userInfoEndpoint": "${API_URL}",
+                      "scopes": ["openid", "profile", "email"]
+                      }
+                  ]
+              }
+              EOF
+            shell:
+              darwin: bash
+              linux: bash
           - wait:
               cluster:
                 kind: StatefulSet

--- a/values/common.yaml
+++ b/values/common.yaml
@@ -24,3 +24,8 @@ nginx:
   enabled: false
 postgresql:
   enabled: false
+
+global:
+  license:
+    secret: artifactory-license
+    dataKey: license


### PR DESCRIPTION
After a license key is added, it exposes the rest of the settings, but something that could be done is add the license through a secret and then we could create the oauth sso provider through artifactory api. 

I'm not enabling it by default. Something to remember is that when it's enabled, it disables the other login creds for admin. 

![image](https://github.com/user-attachments/assets/a0a3cba7-57dd-4f5d-938f-d4682ead8b28)
